### PR TITLE
Remove deprecated cl require

### DIFF
--- a/nyan-mode.el
+++ b/nyan-mode.el
@@ -53,8 +53,6 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
-
 (defconst +nyan-directory+ (file-name-directory (or load-file-name buffer-file-name)))
 
 (defconst +nyan-cat-size+ 3)


### PR DESCRIPTION
Remove deprecated `cl` require.
From Emacs-27, Emacs warn requiring deprecated `cl` library.

I just remove require `cl`.  Because you require `cl` library but
there're no using `cl` macros...?