### PR TITLE
Fix for sml-modeline.el link

### DIFF
--- a/README.org
+++ b/README.org
@@ -85,7 +85,7 @@ will hopefully track it down and fix it soon.
 Thanks to everyone contributing patches, bug repots and ideas! The Emacs world is forever in your debt!
 
 Code and idea inspired by sml-modeline.el, written by Lennart Borgman.
-See: http://bazaar.launchpad.net/~nxhtml/nxhtml/main/annotate/head%3A/util/sml-modeline.el
+See: https://github.com/emacsmirror/sml-modeline/blob/master/sml-modeline.el
 
 For animated Nyan Cat, I used frames [[http://media.photobucket.com/image/nyan%20cat%20sprites/DryBowser455/th_NyanCatSprite.png?t=1304659408][by DryBowser455]].
 


### PR DESCRIPTION
Fixes part of #52 

Unfortunately, the link for the animated Nyan Cat does not show up on any standard archive crawler.