### PR TITLE
Fix math for narrowed windows and visual-fill-column'd windows

### DIFF
--- a/nyan-mode.el
+++ b/nyan-mode.el
@@ -209,7 +209,8 @@ This can be t or nil."
   (round (/ (* (round (* 100
                          (/ (- (float (point))
                                (float (point-min)))
-                            (float (point-max)))))
+                            (float (- (point-max)
+                                      (point-min))))))
                (- nyan-bar-length nyan-cat-size))
             100)))
 
@@ -244,7 +245,7 @@ This can be t or nil."
 
 (defun nyan-create ()
   "Return the Nyan Cat indicator to be inserted into mode line."
-  (if (< (window-width) nyan-minimum-window-width)
+  (if (< (window-total-width) nyan-minimum-window-width)
       ""                                ; disabled for too small windows
     (let* ((rainbows (nyan-number-of-rainbows))
            (outerspaces (- nyan-bar-length rainbows nyan-cat-size))


### PR DESCRIPTION
In modes like visual-fill-column, using window-total-width calculates the actual width of the mode-line.

When the buffer is narrowed, the nyan cat should (in my mind) update relative to the narrowed part of the buffer.

I fixed both of these math issues. Let me know if I should submit two separate pull requests instead.