### PR TITLE
Fix option's type

### DIFF
--- a/nyan-mode.el
+++ b/nyan-mode.el
@@ -85,7 +85,7 @@ reapply them immediately."
 
 (defcustom nyan-animation-frame-interval 0.2
   "Number of seconds between animation frames."
-  :type 'float
+  :type 'number
   :set (lambda (sym val)
          (set-default sym val)
          (nyan-refresh))


### PR DESCRIPTION
```lisp
(setopt nyan-animation-frame-interval 1)
```

gives me a warning:

```
Warning (emacs): Value ‘1’ does not match type float
```